### PR TITLE
Kubernetes account validation improvements

### DIFF
--- a/proto/providers.proto
+++ b/proto/providers.proto
@@ -25,7 +25,8 @@ message Kubernetes {
 
         // A list of resource kinds this Spinnaker account can deploy and
         // will cache. When no kinds are configured, this defaults to all kinds
-        // described [here](https://spinnaker.io/reference/providers/kubernetes-v2/).
+        // described here:
+        // https://spinnaker.io/reference/providers/kubernetes-v2/.
         // This can only be set when omitKinds is empty or not set.
         repeated string kinds = 3;
 


### PR DESCRIPTION
**- validate halconfig clone**

  There were a few options for deep cloning in go: 1) manually use reflection :scream:  2) manually marshall/unmarshall to and from JSON :cry: 3) use one of the many libraries that does either 1 or 2 under the hood, 4) run the [code generator](https://github.com/kubernetes/gengo/tree/master/examples/deepcopy-gen) Kubernetes wrote for itself to solve this problem, which is actually really cool because it creates deep-clone methods for any specially-commented struct. 4 seemed heavyweight at this point since for some reason it seems like [you need to write a script](https://github.com/kubernetes/gengo/blob/master/examples/deepcopy-gen/main.go) rather than passing some flag to protoc, so I went with 3; happy to rip this out at some point if we change our mind. :man_shrugging: 

**- remove markdown link**

  Who needs it? Not Kubernetes.

**- add remaining k8s account validators**

  Added validators from Halyard's [KubernetesAccountValidator](https://github.com/spinnaker/halyard/blob/master/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/kubernetes/KubernetesAccountValidator.java). Intentionally omitted the validation that 1) parses your kubeconfig 2) tries to communicate with your cluster.