### PR TITLE
Add Release arm64

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,3 +9,8 @@ builds:
     - amd64
     - 386
     - arm64
+  ignore:
+    - goos: darwin
+      goarch: 386
+    - goos: windows
+      goarch: arm64

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,10 +1,11 @@
 builds:
 - ldflags:
     - -s -w -X github.com/spinnaker/kleat/pkg/version.Version={{.Version}} -X github.com/spinnaker/kleat/pkg/version.Commit={{.Commit}} -X github.com/spinnaker/kleat/pkg/version.Date={{.Date}}
-  # By default, will build each specified $GOOS for the default $GOARCH options of 386 and amd64.
-  # If necessary in the future, can specify non-default $GOARCH options under `goarch` key per
-  # https://goreleaser.com/customization/build/.
   goos:
     - darwin
     - linux
     - windows
+  goarch:
+    - amd64
+    - 386
+    - arm64

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,6 +8,5 @@ pull_request_rules:
     actions:
       merge:
         method: squash
-        strict: smart
       label:
         add: ["auto merged"]


### PR DESCRIPTION
Hello.

I added release binary of arm64 arch to goos darwin and linux.

I tested workflow at https://github.com/nktks/kleat/actions/runs/2759808342 and released at https://github.com/nktks/kleat/releases/tag/v0.6.1
and tested to execute `kleat -v` at only darwin_arm64 binary.

And I fixed mergify setting https://github.com/spinnaker/kleat/pull/203#issuecomment-1200058810
Thanks! 